### PR TITLE
fix: create a pull request also on change hidden files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,3 +89,20 @@ jobs:
       - run: "git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git :test-create-new-pull-request-with-multiple-commits"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # expect to detect changes in a hidden file:
+  # https://github.com/gr2m/create-or-update-pull-request-action/pull/262
+  hiddenFile:
+    name: "[TEST] Create or update pull request for hidden file"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: "date > .github/test.txt"
+      - run: "npm ci"
+      - run: "npm run build"
+      - uses: ./
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTIONS_STEP_DEBUG: true
+        with:
+          commit-message: "Just testing [skip ci]"

--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ async function main() {
 }
 
 async function getLocalChanges(path) {
-  const output = await runShellCommand(`git status ${path || "*"}`);
+  const output = await runShellCommand(`git status ${path}`);
 
   if (/nothing to commit, working tree clean/i.test(output)) {
     return {};


### PR DESCRIPTION
If the hidden file or directory (e.g., `.github` `.env`) are changed, this action behaves as `No local changes` without `path` option. 
In the default shell, `*` ignores hidden files.

**before**

The hidden files are skipped to create a pull request.

- `.github/workflows/test.yml` => ignored
- `.env` => ignored
- `path/to/.env` => not ignored
- `foo` => not ignored

**after**

On modifying any file, creates a pull request.