### PR TITLE
fix: use single quotes to prevent bash command substitution

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ async function main() {
 
     core.debug(`Local changes found`);
 
-    await runShellCommand(`git checkout -b "${TEMPORARY_BRANCH_NAME}"`);
+    await runShellCommand(`git checkout -b '${TEMPORARY_BRANCH_NAME}'`);
 
     const gitUser = await getGitUser();
     if (gitUser) {
@@ -104,7 +104,7 @@ async function main() {
     }
 
     await runShellCommand(
-      `git commit -m "${inputs.commitMessage}" --author "${inputs.author}"`
+      `git commit -m '${inputs.commitMessage}' --author '${inputs.author}'`
     );
 
     const currentBranch = await runShellCommand(
@@ -119,7 +119,7 @@ async function main() {
         `git fetch https://x-access-token:${process.env.GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}.git ${DEFAULT_BRANCH}:${DEFAULT_BRANCH}`
       );
       await runShellCommand(`git stash --include-untracked`);
-      await runShellCommand(`git rebase -X theirs "${DEFAULT_BRANCH}"`);
+      await runShellCommand(`git rebase -X theirs '${DEFAULT_BRANCH}'`);
     }
 
     core.debug(`Try to fetch and checkout remote branch "${inputs.branch}"`);
@@ -220,10 +220,10 @@ async function getGitUser() {
 
 async function setGitUser({ name, email }) {
   core.debug(`Configuring user.name as "${name}"`);
-  await runShellCommand(`git config --global user.name "${name}"`);
+  await runShellCommand(`git config --global user.name '${name}'`);
 
   core.debug(`Configuring user.email as "${email}"`);
-  await runShellCommand(`git config --global user.email "${email}"`);
+  await runShellCommand(`git config --global user.email '${email}'`);
 }
 
 async function checkOutRemoteBranch(branch) {


### PR DESCRIPTION
Came across this when writing my `commit-message`:

```
  commit-message: 'feat: update `@octokit/webhooks-definitions`'
```

Backticks are a deprecated way of running a subcommand and capturing its results in Bash, meaning the above commit message comes out as `feat: update` since `@octokit/webhooks-definitions` is not a bash command.

Bash only does substitution in double-quotes, so by using single-quotes this problem won't occur. 

While there could arguably be some uses, I don't think they're that practical at least by default, and you should be able to execute commands in another step and use native action substitution.