### PR TITLE
docs: note on persist-credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+`persist-credentials: false` is crucial otherwise Git push is performed with `github.token` and not the token you configure using the `env: GITHUB_TOKEN`.
+
 Customizations
 
 ```yml


### PR DESCRIPTION
I was banging my head why the action did not run with the token (and its permissions) I specified. Thanks to Github support I found out about `persist-credentials` and seeing it mentioned here, I originally did not understand why I should include it and hence did not include it 😅 And thanks to that my head still hurts...

Just a small note for others to save their headaches...