### PR TITLE
Enable Adding Reviewers to PR

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -22,3 +22,4 @@ jobs:
           path: "test.txt"
           commit-message: "debug"
           author: "Gregor Martynus <39992+gr2m@users.noreply.github.com>"
+          reviewers: gr2m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,3 +209,39 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: ${{ fromJson(steps.get-pull-request.outputs.data).title != 'Updated test pull request' }}
         run: 'echo "Pull request title is  \"${{ fromJson(steps.get-pull-request.outputs.data).title }}\" but expected \"Updated test pull request\"" && exit 1'
+
+  addReviewers:
+    name: "[TEST] Add Reviewers"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - run: "date > test.txt"
+      - run: "npm ci"
+      - run: "npm run build"
+      - uses: ./
+        id: run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTIONS_STEP_DEBUG: true
+        with:
+          title: Test Add Reviewers
+          body: This pull request is part of the CI  - please ignore.
+          branch: test-add-reviewers-${{ github.run_number }}
+          commit-message: "Just testing [skip ci]"
+          reviewers: gr2m
+      - uses: octokit/request-action@v2.x
+        id: get-pull-request
+        with:
+          route: GET /repos/{owner}/{repo}/pulls/{pull_number}
+          owner: gr2m
+          repo: create-or-update-pull-request-action
+          pull_number: ${{ steps.run.outputs.pull-request-number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: "git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git :test-add-reviewers-${{ github.run_number }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: ${{ !contains(toJson(fromJson(steps.get-pull-request.outputs.data).requested_reviewers.*.login), 'gr2m') }}
+        run: 'echo "Requested reviewers are \"${{ toJson(fromJson(steps.get-pull-request.outputs.data).requested_reviewers.*.login) }}\" but expected \"[\n gr2m \n]\"" && exit 1'

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ with:
   author: "Lorem J. Ipsum <lorem@example.com>"
   labels: label1, label2
   assignees: user1, user2
+  reviewers: user1, user2
   auto-merge: squash
   update-pull-request-title-and-body: false
 ```

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   assignees:
     description: Comma separated list of assignees to apply to the pull request
     required: false
+  reviewers:
+    description: Comma separated list of reviewers to apply to the pull request
+    required: false
   auto-merge:
     description: "Enable auto merge for pull request. Requires auto merging to be enabled in repository settings"
     required: false

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ async function main() {
       author: core.getInput("author"),
       labels: core.getInput("labels"),
       assignees: core.getInput("assignees"),
+      reviewers: core.getInput("reviewers"),
       autoMerge: core.getInput("auto-merge"),
       updatePRTitleAndBody: core.getInput("update-pull-request-title-and-body"),
     };
@@ -219,6 +220,22 @@ async function main() {
         }
       );
       core.info(`Assignees added: ${assignees.join(", ")}`);
+      core.debug(inspect(data));
+    }
+  
+    if (inputs.reviewers) {
+      core.debug(`Adding reviewers: ${inputs.reviewers}`);
+      const reviewers = inputs.reviewers.trim().split(/\s*,\s*/);
+      const { data } = await octokit.request(
+        `POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers`,
+        {
+          owner,
+          repo,
+          pull_number: number,
+          reviewers,
+        }
+      );
+      core.info(`Reviewers added: ${reviewers.join(", ")}`);
       core.debug(inspect(data));
     }
 


### PR DESCRIPTION
Hey, great overall GH action. 

Just wanted to open a PR with a suggested feature of requesting reviewers. Added the relevant options (I believe), as well as added a test. 

The test adds @gr2m as a requested reviewer, although not sure of any other dummy user to add as a reviewer (can't add the github actions bot as a test user).