### PR TITLE
chore: bump nodens version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
       - run: date > test.txt
       - run: npm ci
       - run: npm run build
@@ -42,6 +46,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
       - run: date > test.txt
       - run: npm ci
       - run: npm run build
@@ -80,6 +88,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
       - run: date > file1.txt
       - run: date > file2.txt
       - run: npm ci
@@ -137,6 +149,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
       - run: date > test.txt
       - run: npm ci
       - run: npm run build
@@ -162,6 +178,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
       - run: date > .github/test.txt
       - run: npm ci
       - run: npm run build
@@ -178,6 +198,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
       - run: date > test.txt
       - run: npm ci
       - run: npm run build
@@ -243,6 +267,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
       - run: date > test.txt
       - run: npm ci
       - run: npm run build

--- a/action.yml
+++ b/action.yml
@@ -57,5 +57,5 @@ outputs:
     description: "'updated', 'created', 'unchanged' based if the PR was created, updated or nothing happened"
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
Given that GitHub has deprecated warning across all GitHub Actions to deprecate node12, this action should also be bumped into node16.

For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/