### PR TITLE
fix(README): use checkout@v4 in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
   update_routes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - run: "date > datetime.txt" # create or update a test.txt file


### PR DESCRIPTION
The README example uses `checkout@v2`. v2 and v3 are both dead, v4 is now current.