### PR TITLE
Included permissions in the Minimal workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ on:
     # https://crontab.guru/every-night-at-midnight
     - cron: "0 0 * * *"
 
+# permissions can also be applied at job level
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update_routes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Should close https://github.com/gr2m/create-or-update-pull-request-action/issues/557.

Info is get from [here](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) but since I faced the same issue this week, giving back felt the right move.

---

Opinion: I've added the `permission` at the top-level, but they can also be provided at the job-level if wanted.

I am happy to change it if you think it would be a better approach.